### PR TITLE
Variance is not visible. Std variation is visible.

### DIFF
--- a/Module1/IntroductionToMachineLearning.ipynb
+++ b/Module1/IntroductionToMachineLearning.ipynb
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Examine these results. You can see the mean and variance of each column in the list printed. The mean is zero and the standard deviation is approximately 1.0.\n",
+    "\Examine these results. The mean of each column is zero and the standard deviation is approximately 1.0.\n",
     "\n",
     "The methods in the scikit-learn package requires numeric numpy arrays as arguments. Therefore, the strings indicting species must be re-coded as numbers. The code in the cell below does this using a dictionary lookup. Execute this code and examine the head of the data frame. "
    ]


### PR DESCRIPTION
Text should not refer to variance since it's not visible in the output.

Using Python 3.6.5 installed via Anaconda on Windows.